### PR TITLE
TravisCI: Overwrite OSX system `md5sum` with Homebrew version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ cache:
     - "node_modules"
     - $HOME/Library/Caches/Homebrew # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci/41386136#41386136
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; brew link --overwrite md5sha1sum; fi


### PR DESCRIPTION
This should fix the following error from e.g. https://travis-ci.org/josephfrazier/prettier_d/jobs/628931157:

    Error: The `brew link` step did not complete successfully
    The formula built, but is not symlinked into /usr/local
    Could not symlink bin/md5sum
    Target /usr/local/bin/md5sum
    is a symlink belonging to coreutils. You can unlink it:
      brew unlink coreutils

    To force the link and overwrite all conflicting files:
      brew link --overwrite md5sha1sum

    To list all files that would be deleted:
      brew link --overwrite --dry-run md5sha1sum

    Possible conflicting files are:
    /usr/local/bin/md5sum -> /usr/local/Cellar/coreutils/8.31/bin/md5sum
    /usr/local/bin/sha1sum -> /usr/local/Cellar/coreutils/8.31/bin/sha1sum