### PR TITLE
package.json: Remove some potential conflicts with `prettier` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "prettier",
+  "name": "prettier_d",
   "version": "1.19.1",
   "description": "Prettier is an opinionated code formatter",
   "bin": {
-    "prettier": "./bin/prettier.js",
     "prettier_d": "bin/prettier_d.js"
   },
-  "repository": "prettier/prettier",
-  "homepage": "https://prettier.io",
+  "repository": "josephfrazier/prettier_d",
+  "homepage": "https://github.com/josephfrazier/prettier_d",
   "author": "James Long",
   "contributors": [
     "Maximilian Antoni <mail@maxantoni.de> (http://maxantoni.de/)",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.19.1",
   "description": "Prettier is an opinionated code formatter",
   "bin": {
+    "prettier": "./bin/prettier.js",
     "prettier_d": "bin/prettier_d.js"
   },
   "repository": "josephfrazier/prettier_d",


### PR DESCRIPTION
See https://github.com/josephfrazier/prettier_d/issues/14#issuecomment-569227911:

> *I've tried installing it via GitHub link, it still somewhat installs `prettier`?*

> I think you have to change your package name inside [package.json](https://github.com/josephfrazier/prettier_d/blob/master/package.json#L2)
>
> Currently, it says `prettier`, If this is meant to be forked and meant to be published in npm, shouldn't it be `prettier_d` instead? Otherwise, it'll just conflict with the current `prettier`?