### PR TITLE
Make `synchronous-promise` and `strip-ansi` production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "semver": "6.3.0",
     "sinon": "7.2.2",
     "string-width": "4.1.0",
+    "strip-ansi": "5.2.0",
     "supports-color": "^4.2.1",
+    "synchronous-promise": "2.0.10",
     "typescript": "3.7.2",
     "unicode-regex": "3.0.0",
     "unified": "8.4.1",
@@ -122,8 +124,6 @@
     "rollup-plugin-terser": "5.1.2",
     "shelljs": "0.8.3",
     "snapshot-diff": "0.4.0",
-    "strip-ansi": "5.2.0",
-    "synchronous-promise": "2.0.10",
     "tempy": "0.2.1",
     "terser-webpack-plugin": "2.2.1",
     "webpack": "4.41.2"


### PR DESCRIPTION
See https://github.com/josephfrazier/prettier_d/issues/14
and https://github.com/josephfrazier/prettier_d/issues/28

> The background server invokes the `runPrettier.js` file:
>
> https://github.com/josephfrazier/prettier_d/blob/937a59d837788b176b243b4f0df936f990daa170/lib/server.js#L13
>
> which uses `synchronous-promise`, but that package was only listed as a devDependency, rather than a production dependency.