### PR TITLE
Remove `prettier` binary to avoid conflict with `prettier` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.19.1",
   "description": "Prettier is an opinionated code formatter",
   "bin": {
-    "prettier": "./bin/prettier.js",
     "prettier_d": "bin/prettier_d.js"
   },
   "repository": "josephfrazier/prettier_d",

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -9,7 +9,7 @@ const SynchronousPromise = require("synchronous-promise").SynchronousPromise;
 const isProduction = process.env.NODE_ENV === "production";
 const prettierRootDir = isProduction ? process.env.PRETTIER_DIR : "../";
 const prettierPkg = require(path.join(prettierRootDir, "package.json"));
-const prettierCli = path.join(prettierRootDir, prettierPkg.bin.prettier);
+const prettierCli = path.join(prettierRootDir, 'bin/prettier.js');
 
 const thirdParty = isProduction
   ? path.join(prettierRootDir, "./third-party")


### PR DESCRIPTION
This fixes the problem described in commit e65f7d5:

> package.json: Restore `prettier` binary so tests pass (WTF)