### PR TITLE
TravisCI: Don't install md5sha1sum on MacOS, coreutils is already installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,3 @@ cache:
   directories:
     - "node_modules"
     - $HOME/Library/Caches/Homebrew # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci/41386136#41386136
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; brew link --overwrite md5sha1sum; fi


### PR DESCRIPTION
See https://travis-ci.org/github/josephfrazier/prettier_d/jobs/708875052
and https://travis-ci.org/github/josephfrazier/prettier_d/jobs/708875020