### PR TITLE
Use os.homedir() instead of USERPROFILE or HOME environment variables

### DIFF
--- a/lib/portfile.js
+++ b/lib/portfile.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const os = require("os");
 const fs = require("fs");
 const findProjectRoot = require("find-project-root");
 
@@ -7,8 +8,7 @@ let dir;
 try {
   dir = findProjectRoot(process.cwd());
 } catch (e) {
-  const homeEnv = process.platform === "win32" ? "USERPROFILE" : "HOME";
-  dir = process.env[homeEnv];
+  dir = os.homedir();
 }
 
 const dataFile = dir + "/.prettier_d";


### PR DESCRIPTION
See https://github.com/josephfrazier/prettier_d/issues/70:

> I tried to debug the issue and noticed that when executing the command outside of project with .git, [the `dataFile` variable in portfile.js](https://github.com/josephfrazier/prettier_d/blob/master/lib/portfile.js?rgh-link-date=2021-02-05T18%3A01%3A42Z#L14) has value `null/.prettier_d`. The `try...catch` over there doesn't help and `dir` got null.

This should help the `catch` case get the proper home directory, instead
of `null`.