### PR TITLE
Fix findProjectRoot fallback

### DIFF
--- a/lib/portfile.js
+++ b/lib/portfile.js
@@ -4,12 +4,7 @@ const os = require("os");
 const fs = require("fs");
 const findProjectRoot = require("find-project-root");
 
-let dir;
-try {
-  dir = findProjectRoot(process.cwd());
-} catch (e) {
-  dir = os.homedir();
-}
+const dir = findProjectRoot(process.cwd()) || os.homedir();
 
 const dataFile = dir + "/.prettier_d";
 


### PR DESCRIPTION
See https://github.com/josephfrazier/prettier_d/issues/70#issuecomment-776086700:

> @josephfrazier, I don't think #71 will fix this. What I meant with "The `try...catch` over there doesn't help and `dir` got null." is that [this line](https://github.com/josephfrazier/prettier_d/blob/master/lib/portfile.js?rgh-link-date=2021-02-09T16%3A59%3A19Z#L9):
>
> ```js
> dir = findProjectRoot(process.cwd());
> ```
>
> never throws error even if `prettier_d` is executed outside of `.git` or `.gh`-root folders. It just simply returned `null`, and the [`dataFile` variable at line 14](https://github.com/josephfrazier/prettier_d/blob/master/lib/portfile.js?rgh-link-date=2021-02-09T16%3A59%3A19Z#L14) got `null/.prettier_d`.